### PR TITLE
Use whole numbers for market share in HHI

### DIFF
--- a/tokenomics_decentralization/analyze.py
+++ b/tokenomics_decentralization/analyze.py
@@ -74,8 +74,6 @@ def analyze_snapshot(conn, ledger, snapshot, force_compute, no_clustering):
         if no_clustering:
             metric_name = 'non-clustered ' + metric_name
 
-        logging.info(f'Computing {metric_name}')
-
         val = cursor.execute('SELECT value FROM metrics WHERE snapshot_id=? and name=?', (snapshot_id, metric_name)).fetchone()
         if val and not force_compute:
             metric_value = val[0]
@@ -86,6 +84,7 @@ def analyze_snapshot(conn, ledger, snapshot, force_compute, no_clustering):
                 else:
                     entries = get_balance_entries(cursor, snapshot_id)
 
+            logging.info(f'Computing {metric_name}')
             if 'tau' in metric_name:
                 threshold = float(metric_name.split('=')[1])
                 metric_value = compute_tau(entries, circulation, threshold)[0]

--- a/tokenomics_decentralization/metrics.py
+++ b/tokenomics_decentralization/metrics.py
@@ -30,7 +30,7 @@ def compute_gini(entries, circulation):
 def compute_hhi(entries, circulation):
     hhi = 0
     for entry in entries:
-        market_share = int(entry[1]) / circulation
+        market_share = int(entry[1]) / circulation * 100
         hhi += market_share**2
 
     return hhi


### PR DESCRIPTION
To be consistent with our previous work (and with the US Department of Justice guidelines) I updated the HHI calculations to use whole numbers for market shares (e.g. 40 instead of 0.4 for 40%), which results in values in the range [0, 10000].

Also updated the location of the "Computing {metric}" print command, so that it is only shown when the metric is actually being computed (and not when the results are fetched from a db for example)