### PR TITLE
Update gitignore for multiple google keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@
 output
 input/*_raw_data.json
 .coverage
-google-service-account-key.json
+google-service-account-key-?.json


### PR DESCRIPTION
Updated .gitignore to match the new filename format we use for google service account keys